### PR TITLE
Fix unseal-period CLI option  

### DIFF
--- a/cmd/unseal.go
+++ b/cmd/unseal.go
@@ -77,8 +77,9 @@ to quickly create a Cobra application.`,
 
 				logrus.Infof("successfully unsealed vault")
 			}()
-			// wait 30 seconds before trying again
-			time.Sleep(time.Second * 30)
+
+			// wait cfgUnsealPeriod before trying again
+			time.Sleep(appConfig.GetDuration(cfgUnsealPeriod))
 		}
 	},
 }


### PR DESCRIPTION
```release-note
Right now you can configure the `unseal-period` but it's not being used. This utilizes it in the sleep. 
```
