### PR TITLE
Creates local mode for unseal key shares in path

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ const cfgGoogleCloudStoragePrefix = "google-cloud-storage-prefix"
 const cfgAWSKMSKeyID = "aws-kms-key-id"
 const cfgAWSSSMKeyPrefix = "aws-ssm-key-prefix"
 
-const cfgLocalKey = "local-key"
+const cfgLocalKeyDir = "local-key-dir"
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -101,6 +101,5 @@ func init() {
 	// AWS SSM Parameter Storage flags
 	configStringVar("aws-ssm-key-prefix", "", "The Key Prefix for SSM Parameter store")
 
-	configStringVar("local-key", "", "The local key in path to be used against the vault server")
-
+	configStringVar("local-key-dir", "", "Directory of key shares in path")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ const cfgSecretThreshold = "secret-threshold"
 const cfgMode = "mode"
 const cfgModeValueAWSKMSSSM = "aws-kms-ssm"
 const cfgModeValueGoogleCloudKMSGCS = "google-cloud-kms-gcs"
+const cfgModeValueLocal = "local"
 
 const cfgGoogleCloudKMSProject = "google-cloud-kms-project"
 const cfgGoogleCloudKMSLocation = "google-cloud-kms-location"
@@ -30,6 +31,8 @@ const cfgGoogleCloudStoragePrefix = "google-cloud-storage-prefix"
 const cfgAWSKMSKeyID = "aws-kms-key-id"
 const cfgAWSSSMKeyPrefix = "aws-ssm-key-prefix"
 
+const cfgLocalKey = "local-key"
+
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "vault-unsealer",
@@ -38,7 +41,7 @@ var RootCmd = &cobra.Command{
 Hashicorp Vault.
 
 It will continuously attempt to unseal the target Vault instance, by retrieving
-unseal keys from a Google Cloud KMS keyring.
+unseal keys from a Google Cloud, AWS KMS keyring or local in path
 `,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
@@ -75,7 +78,7 @@ func init() {
 	configStringVar(
 		cfgMode,
 		cfgModeValueGoogleCloudKMSGCS,
-		fmt.Sprintf("Select the mode to use '%s' => Google Cloud Storage with encryption using Google KMS; '%s' => AWS SSM parameter store using AWS KMS encryption", cfgModeValueGoogleCloudKMSGCS, cfgModeValueAWSKMSSSM),
+		fmt.Sprintf("Select the mode to use '%s' => Google Cloud Storage with encryption using Google KMS; '%s' => AWS SSM parameter store using AWS KMS encryption; %s => Use local key in path", cfgModeValueGoogleCloudKMSGCS, cfgModeValueAWSKMSSSM, cfgModeValueLocal),
 	)
 
 	// Secret config
@@ -97,5 +100,7 @@ func init() {
 
 	// AWS SSM Parameter Storage flags
 	configStringVar("aws-ssm-key-prefix", "", "The Key Prefix for SSM Parameter store")
+
+	configStringVar("local-key", "", "The local key in path to be used against the vault server")
 
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,7 +78,7 @@ func init() {
 	configStringVar(
 		cfgMode,
 		cfgModeValueGoogleCloudKMSGCS,
-		fmt.Sprintf("Select the mode to use '%s' => Google Cloud Storage with encryption using Google KMS; '%s' => AWS SSM parameter store using AWS KMS encryption; %s => Use local key in path", cfgModeValueGoogleCloudKMSGCS, cfgModeValueAWSKMSSSM, cfgModeValueLocal),
+		fmt.Sprintf("Select the mode to use '%s' => Google Cloud Storage with encryption using Google KMS; '%s' => AWS SSM parameter store using AWS KMS encryption; %s => Use local keys in path", cfgModeValueGoogleCloudKMSGCS, cfgModeValueAWSKMSSSM, cfgModeValueLocal),
 	)
 
 	// Secret config

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -71,7 +71,7 @@ func kvStoreForConfig(cfg *viper.Viper) (kv.Service, error) {
 		return kms, nil
 
 	case cfgModeValueLocal:
-		return local.New(cfg.GetString(cfgLocalKey))
+		return local.New(cfg.GetString(cfgLocalKeyDir))
 
 	default:
 		return nil, fmt.Errorf("Unsupported backend mode: '%s'", cfg.GetString(cfgMode))

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jetstack/vault-unsealer/pkg/kv/aws_ssm"
 	"github.com/jetstack/vault-unsealer/pkg/kv/cloudkms"
 	"github.com/jetstack/vault-unsealer/pkg/kv/gcs"
+	"github.com/jetstack/vault-unsealer/pkg/kv/local"
 
 	"github.com/jetstack/vault-unsealer/pkg/vault"
 )
@@ -31,7 +32,8 @@ func vaultConfigForConfig(cfg *viper.Viper) (vault.Config, error) {
 
 func kvStoreForConfig(cfg *viper.Viper) (kv.Service, error) {
 
-	if cfg.GetString(cfgMode) == cfgModeValueGoogleCloudKMSGCS {
+	switch cfg.GetString(cfgMode) {
+	case cfgModeValueGoogleCloudKMSGCS:
 
 		g, err := gcs.New(
 			cfg.GetString(cfgGoogleCloudStorageBucket),
@@ -54,9 +56,8 @@ func kvStoreForConfig(cfg *viper.Viper) (kv.Service, error) {
 		}
 
 		return kms, nil
-	}
 
-	if cfg.GetString(cfgMode) == cfgModeValueAWSKMSSSM {
+	case cfgModeValueAWSKMSSSM:
 		ssm, err := aws_ssm.New(cfg.GetString(cfgAWSSSMKeyPrefix))
 		if err != nil {
 			return nil, fmt.Errorf("error creating AWS SSM kv store: %s", err.Error())
@@ -68,7 +69,11 @@ func kvStoreForConfig(cfg *viper.Viper) (kv.Service, error) {
 		}
 
 		return kms, nil
-	}
 
-	return nil, fmt.Errorf("Unsupported backend mode: '%s'", cfg.GetString(cfgMode))
+	case cfgModeValueLocal:
+		return local.New(cfg.GetString(cfgLocalKey))
+
+	default:
+		return nil, fmt.Errorf("Unsupported backend mode: '%s'", cfg.GetString(cfgMode))
+	}
 }

--- a/pkg/kv/local/local.go
+++ b/pkg/kv/local/local.go
@@ -3,34 +3,38 @@ package local
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/mitchellh/go-homedir"
 )
 
 type Local struct {
-	keyPath string
+	keyDir string
 }
 
-func New(keyPath string) (*Local, error) {
-	path, err := homedir.Expand(keyPath)
+func New(keyDir string) (*Local, error) {
+	dir, err := homedir.Expand(keyDir)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Local{
-		keyPath: path,
+		keyDir: dir,
 	}, nil
 }
 
 func (l *Local) Set(key string, value []byte) error {
-	return ioutil.WriteFile(l.keyPath, value, os.FileMode(0600))
+	path := filepath.Join(l.keyDir, key)
+	return ioutil.WriteFile(path, value, os.FileMode(0600))
 }
 
 func (l *Local) Get(key string) ([]byte, error) {
-	return ioutil.ReadFile(l.keyPath)
+	path := filepath.Join(l.keyDir, key)
+	return ioutil.ReadFile(path)
 }
 
 func (l *Local) Test(key string) error {
-	_, err := os.Stat(l.keyPath)
+	path := filepath.Join(l.keyDir, key)
+	_, err := os.Stat(path)
 	return err
 }

--- a/pkg/kv/local/local.go
+++ b/pkg/kv/local/local.go
@@ -1,0 +1,36 @@
+package local
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+type Local struct {
+	keyPath string
+}
+
+func New(keyPath string) (*Local, error) {
+	path, err := homedir.Expand(keyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Local{
+		keyPath: path,
+	}, nil
+}
+
+func (l *Local) Set(key string, value []byte) error {
+	return ioutil.WriteFile(l.keyPath, value, os.FileMode(0600))
+}
+
+func (l *Local) Get(key string) ([]byte, error) {
+	return ioutil.ReadFile(l.keyPath)
+}
+
+func (l *Local) Test(key string) error {
+	_, err := os.Stat(l.keyPath)
+	return err
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a `local` mode to use an unseal key in path.

```release-note
Adds local mode for unseal keys in path
```

/assign @simonswine 