### PR TITLE
Removes flag.Parse() from root to display --help output

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"flag"
-
 	"github.com/jetstack/vault-unsealer/cmd"
 )
 
@@ -13,7 +11,6 @@ var (
 )
 
 func main() {
-	flag.Parse()
 	cmd.Version.Version = version
 	cmd.Version.Commit = commit
 	cmd.Version.BuildDate = date


### PR DESCRIPTION
Signed-off-by: JoshVanL <vleeuwenjoshua@gmail.com>

fixes #41 

Removes flags.Parse() from root to ensure flags can be parsed for the root command. This enables flags inc `--help` to display help information.

/assign @simonswine 